### PR TITLE
Fix __toString error return null

### DIFF
--- a/Entity/BaseMetaTag.php
+++ b/Entity/BaseMetaTag.php
@@ -36,7 +36,7 @@ abstract class BaseMetaTag
 
     public function __toString()
     {
-        return $this->title;
+        return (string) $this->title;
     }
 
     /**


### PR DESCRIPTION
Fix error in BaseMetaTag, cast to string the return of __toString function